### PR TITLE
Updated utils.compat.Directive import

### DIFF
--- a/sphinxcontrib/github.py
+++ b/sphinxcontrib/github.py
@@ -12,7 +12,10 @@
 
 from __future__ import absolute_import, print_function, absolute_import
 
-from sphinx.util.compat import Directive
+try:
+    from sphinx.util.compat import Directive
+except ImportError:
+    from docutils.parsers.rst import Directive
 from docutils.parsers.rst import directives
 from docutils import nodes, utils
 from docutils.parsers.rst.roles import set_classes


### PR DESCRIPTION
Fix this error:

Could not import extension sphinxcontrib.github (exception: cannot import name 'Directive' from 'sphinx.util.compat' (/home/omar/.local/lib/python3.7/site-packages/sphinx/util/compat.py))

sphinx.util.compat.Directive has been deprecated